### PR TITLE
Change default port to 9418

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Usage:
   gearman-exporter [flags]
 
 Flags:
-      --addr string       listen address for metrics handler (default "127.0.0.1:8080")
+      --addr string       listen address for metrics handler (default "127.0.0.1:9418")
       --gearmand string   address of gearmand (default "127.0.0.1:4730")
 ```
 
@@ -47,7 +47,7 @@ Metrics
 Metrics will be exposes on `/metrics`
 
 ```
-curl http://localhost:8080/metrics
+curl http://localhost:9418/metrics
 
 # HELP gearman_status_running number of running jobs
 # TYPE gearman_status_running gauge

--- a/cmd/gearman-exporter/main.go
+++ b/cmd/gearman-exporter/main.go
@@ -43,7 +43,7 @@ var rootCmd = &cobra.Command{
 }
 
 func main() {
-	addr = rootCmd.PersistentFlags().StringP("addr", "", "127.0.0.1:8080", "listen address for metrics handler")
+	addr = rootCmd.PersistentFlags().StringP("addr", "", "127.0.0.1:9418", "listen address for metrics handler")
 	gearmanAddr = rootCmd.PersistentFlags().StringP("gearmand", "", "127.0.0.1:4730", "address of gearmand")
 
 	if err := rootCmd.Execute(); err != nil {

--- a/exporter.go
+++ b/exporter.go
@@ -30,7 +30,7 @@ type OptionsFunc func(*Exporter) error
 // New creates an exporter.
 func New(options ...OptionsFunc) (*Exporter, error) {
 	e := &Exporter{
-		addr:        "127.0.0.1:8080",
+		addr:        "127.0.0.1:9418",
 		gearmanAddr: "127.0.0.1:4730",
 	}
 


### PR DESCRIPTION
Which is now registered at https://github.com/prometheus/prometheus/wiki/Default-port-allocations
Closes #1