### PR TITLE
Add Dockerfile (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,33 @@
 language: go
 go:
 - 1.8.x
+
 notifications:
   email: false
-install:
-- true
+
+services:
+  - docker
+
+install: true
+
 script:
 - make build
+- make docker-build
+
 deploy:
-  provider: releases
-  api_key:
-    secure: C4X1zAtBeUJPBUmGx0mDCAGlGQCdu4p6sJwJ5F2HZoadfPE/V0dCRvhC8hm8TKVyesmtACXYSSqW07Sq6A9CCQkV1BsbYEEovPNN7aSmQccRxOF+podkrkYogj0eQl0SJ3/h8DR2Q81+vStxIsPSXJU2yS/8YXMLUfIXOoANcaAjfWBGyCLU1Pop8IIZwaWB3zGt8va0nsj989yaaUkcnoUjdYq4AybSW1MNNnyrN53iHmeyDfp+UvyPB0TTFBAYO5fUt1mYrMI/bFofHZEMwZY+dw7O30Vrhd+ksgDvSXpGUVxnEuQ910xCnXoOGYuZ3JkmV3khidSZ2ZjaYt6VzbakgLPfidprsK/FQibocC8QCI4c5efa3XaQhZF1u70Q4eL1kQjTWt4zhNFXWj6tZK+RnUQHMSHx67aUGCOOJFCUTPPJjPXg5tttAu7/Z8cOYWCzFW6FgKvaE+JfTxM1X/ngDFkgloI76mT26XZJzuPxSRQhhR+6K6ODI6DZb+Bot+mO/ZCCbmQ2+LD4dO6Iah4NlTq6fCIxQThmbgVeMEgWm0xnd7TU3GgBeOba6pdo6p97H0C/jvpDOgLVQe1q5MUAO6FMu3YaYJYbWW8FHMbMZc6rcjeBlqMbayZpc/n8irwFguYHezZotIpEekzjXnQL3CuGtLjsVB2aKKUSRvU=
-  file:
-    - gearman-exporter.linux.amd64
-    - gearman-exporter.darwin.amd64
-  on:
-    repo: bakins/gearman-exporter
-    tags: true
-  skip_cleanup: true
-    
+  - provider: releases
+    skip_cleanup: true
+    api_key:
+      secure: C4X1zAtBeUJPBUmGx0mDCAGlGQCdu4p6sJwJ5F2HZoadfPE/V0dCRvhC8hm8TKVyesmtACXYSSqW07Sq6A9CCQkV1BsbYEEovPNN7aSmQccRxOF+podkrkYogj0eQl0SJ3/h8DR2Q81+vStxIsPSXJU2yS/8YXMLUfIXOoANcaAjfWBGyCLU1Pop8IIZwaWB3zGt8va0nsj989yaaUkcnoUjdYq4AybSW1MNNnyrN53iHmeyDfp+UvyPB0TTFBAYO5fUt1mYrMI/bFofHZEMwZY+dw7O30Vrhd+ksgDvSXpGUVxnEuQ910xCnXoOGYuZ3JkmV3khidSZ2ZjaYt6VzbakgLPfidprsK/FQibocC8QCI4c5efa3XaQhZF1u70Q4eL1kQjTWt4zhNFXWj6tZK+RnUQHMSHx67aUGCOOJFCUTPPJjPXg5tttAu7/Z8cOYWCzFW6FgKvaE+JfTxM1X/ngDFkgloI76mT26XZJzuPxSRQhhR+6K6ODI6DZb+Bot+mO/ZCCbmQ2+LD4dO6Iah4NlTq6fCIxQThmbgVeMEgWm0xnd7TU3GgBeOba6pdo6p97H0C/jvpDOgLVQe1q5MUAO6FMu3YaYJYbWW8FHMbMZc6rcjeBlqMbayZpc/n8irwFguYHezZotIpEekzjXnQL3CuGtLjsVB2aKKUSRvU=
+    file:
+      - gearman-exporter.linux.amd64
+      - gearman-exporter.darwin.amd64
+    on:
+      repo: bakins/gearman-exporter
+      tags: true
+  - provider: script
+    skip_cleanup: true
+    script: make docker-push
+    on:
+      repo: bakins/gearman-exporter
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ notifications:
 services:
   - docker
 
+env:
+  global:
+    - DOCKER_USERNAME=gearmanexporterbot
+    - secure: GETvpQpzTXEXU0q3ZEYI8UFncgyvonKLYUPDQlHzCiWD9FTxJJOkfmXj7C0XqD7+qROzyQak/EK5ZnbuD6rTYxZbtFOJHA5xJKDytfqdP9KSZnqpMnLnnHi2wM9mVDXsJGqDuEC3SU2sMOPfAnWVjHZlDSs1EGC5n71005CFzdvKyug6waAMV58SyMtmKM05+20SlvHD2feOlZh5hmW8gLoxJ8uTJoVSbTidGHulFPNYheIbJeQxhxK0mYgTrZTf6LeRqWR/TWHF5xkWlJQ8jhNv3Y3UYiDURz3v5NRjSJnip2Vh/pFltNzRzmborBwhJaxdQu1dw6BOphK9BbIhj+ZJ/3l/4z827nOPTJOV8mtApl0TPft8U9+7iWeDlTPZgD9LAd1GO6zEPg55KOw18fbTK7LquIXr0V4DOWMtULUwUrk53zApyVisT9Ga6tsYWf+Qj+mVGqakbsyDV+l05fky0ZZ16aj9roSsXGROY5d4AHK/1Ael04R3GkSGevQIEnrlTjPbdwo7lLq9B7eCnxGgWA9GpXR1cF7seM7Oo6Ak8aFDkNYcABuuchZDo/vINJ+dkXro/1ZcL+na9uhgZ+/+LJzaiZpgpET1aR8ky/mMWS7PGxPgdSRkJ6+nKp7ri4QKzet1jk3MiEkpDlGjmJyPDKtVX/KyOyDXSZ09iAY=
+
 install: true
 
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine:3.7
+
+ADD gearman-exporter.linux.amd64 /usr/bin/gearman-exporter
+RUN chmod a+x /usr/bin/gearman-exporter
+
+ENTRYPOINT [ "/usr/bin/gearman-exporter" ]

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,15 @@ build: $(PLATFORMS)
 
 .PHONY: $(PLATFORMS)
 $(PLATFORMS):
-	CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) go build -o ${NAME}.$(os).$(arch) ./cmd/${NAME}
+	CGO_ENABLED=0 GOOS=$(os) GOARCH=$(arch) go build -o $(NAME).$(os).$(arch) ./cmd/$(NAME)
+
+.PHONY: docker-build
+docker-build:
+	docker build -t gearmanexporter/gearman-exporter:latest .
+
+.PHONY: docker-push
+docker-push:
+	docker login -u "$(DOCKER_USERNAME)" -p "$(DOCKER_PASSWORD)"
+	docker tag gearmanexporter/gearman-exporter:latest gearmanexporter/gearman-exporter:$(VERSION)
+	docker push gearmanexporter/gearman-exporter:latest
+	docker push gearmanexporter/gearman-exporter:$(VERSION)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ gearman-exporter
 Export [gearman](http://gearman.org/) metrics in [Prometheus](https://prometheus.io/) format.
 
 [![Build Status](https://img.shields.io/travis/bakins/gearman-exporter/master.svg)](https://travis-ci.org/bakins/gearman-exporter)
+[![Docker Image](https://img.shields.io/docker/pulls/gearmanexporter/gearman-exporter.svg)](https://hub.docker.com/r/gearmanexporter/gearman-exporter)
 
 
 Usage
@@ -27,6 +28,14 @@ Flags:
 ```
 
 When running, a simple healthcheck is availible on `/healthz`
+
+Docker
+------
+
+A docker image is published from the Travis build to [Docker Hub](https://hub.docker.com/r/gearmanexporter/gearman-exporter).
+```
+docker run -p9418:9418 gearmanexporter/gearman-exporter --addr 0.0.0.0:9418
+```
 
 Metrics
 -------


### PR DESCRIPTION
Based on #4

Adding a Dockerfile and Travis configuration to push the built image to Docker Hub.

@bakins I've created a new *organization* called "gearmanexporter" in Docker Hub to push a docker image to. I will then add a new user with access only to the specific Docker Hub repo "gearmanexporter/gearman-exporter" and add the encrypted credentials to the travis build.
Let me know if you think it should be done differently!

---
note
```
[![Build Status](https://img.shields.io/docker/pulls/gearmanexporter/gearman-exporter.svg)](https://hub.docker.com/r/gearmanexporter/gearman-exporter)
```