### PR TITLE
Add support for darwin/arm64 to Makefile and Docker build for any target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 gearman-exporter.darwin.amd64
 gearman-exporter.linux.amd64
+gearman-exporter.darwin.arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM alpine:3.7
+FROM golang:1-alpine as build
+WORKDIR /go/gearman-exporter
+COPY . .
+RUN go build -o /gearman-exporter ./cmd/gearman-exporter
 
-ADD gearman-exporter.linux.amd64 /usr/bin/gearman-exporter
-RUN chmod a+x /usr/bin/gearman-exporter
-
+FROM alpine:3
+COPY --from=build /gearman-exporter /usr/bin/gearman-exporter
 ENTRYPOINT [ "/usr/bin/gearman-exporter" ]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := gearman-exporter
-PLATFORMS := linux/amd64 darwin/amd64
+PLATFORMS := linux/amd64 darwin/amd64 darwin/arm64
 VERSION := $(shell git describe --tags --abbrev=0)
 
 temp = $(subst /, ,$@)


### PR DESCRIPTION
* Add the `make` targets for Apple M1 silicon
* Build the binary inside Docker allowing `make docker-build` to work on any arch that Docker is being run on